### PR TITLE
Improve perfomance of naive solver

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -4,7 +4,18 @@ These benchmarks are intended as developer-facing. They contain checks to ensure
 
 ## Extra requirements
 
-You need to install [`pyvsc`](https://pyvsc.readthedocs.io/en/latest/introduction.html) in order to run the benchmarks. This is not included in `pyproject.toml` as a dependency to avoid making installation size bigger than necessary.
+You need to install [`pyvsc`](https://pyvsc.readthedocs.io/en/latest/introduction.html) in order to run the benchmarks. This is not included in `constrainedrandom`'s core dependencies to avoid making installation size bigger than necessary. Install it with the `benchmarks` optional dependency group:
+
+```bash
+pip install -e ".[benchmarks]"
+```
+
+Note that `pyvsc` depends on `pyboolector`, which does not provide packages for all platforms (e.g. there is no macOS arm64 support). On unsupported platforms, run the benchmarks in a container, e.g.:
+
+```bash
+docker run --platform linux/amd64 -v "$PWD":/work -w /work python:3.12 \
+    bash -c "pip install -e '.[benchmarks]' && python -m benchmarks"
+```
 
 ## Running
 

--- a/constrainedrandom/internal/randvar.py
+++ b/constrainedrandom/internal/randvar.py
@@ -543,11 +543,7 @@ class RandVar:
                     f" constraints for random variable '{self.name}'.",
                     str(self.debug_info),
                 )
-            problem = constraint.Problem()
-            problem.addVariable(self.name, (value,))
-            for con in constraints:
-                problem.addConstraint(con, (self.name,))
-            value_valid = problem.getSolution() is not None
+            value_valid = all(con(value) for con in constraints)
             if not value_valid:
                 if debug:
                     # Capture all failing values as we go
@@ -628,11 +624,7 @@ class RandVar:
             if iterations >= max_iterations:
                 # This method has failed.
                 return None
-            problem = constraint.Problem()
-            problem.addVariable(self.name, (values,))
-            for con in list_constraints:
-                problem.addConstraint(con, (self.name,))
-            values_valid = problem.getSolution() is not None
+            values_valid = all(con(values) for con in list_constraints)
             if not values_valid:
                 if debug:
                     # Capture all failing values as we go
@@ -696,14 +688,10 @@ class RandVar:
             min_group_size = len(checked) + 1
             for idx in range(min_group_size, length):
                 tmp_values = values[:idx]
-                problem = constraint.Problem()
-                problem.addVariable(self.name, (tmp_values,))
-                for con in list_constraints:
-                    problem.addConstraint(con, (self.name,))
                 # This may fail if the user is relying on the
                 # list being fully-sized in their constraint.
                 try:
-                    tmp_values_valid = problem.getSolution() is not None
+                    tmp_values_valid = all(con(tmp_values) for con in list_constraints)
                 except Exception:
                     tmp_values_valid = False
                 if tmp_values_valid:
@@ -715,11 +703,7 @@ class RandVar:
                     checked = tmp_values
             values = checked + [self.randomize_once(constraints, using_temp_constraints, debug) \
                 for _ in range(length - len(checked))]
-            problem = constraint.Problem()
-            problem.addVariable(self.name, (values,))
-            for con in list_constraints:
-                problem.addConstraint(con, (self.name,))
-            values_valid = problem.getSolution() is not None
+            values_valid = all(con(values) for con in list_constraints)
             if debug and not values_valid:
                 # Capture failure info as we go along
                 self.debug_info.add_failure(

--- a/constrainedrandom/randobj.py
+++ b/constrainedrandom/randobj.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2023 Imagination Technologies Ltd. All Rights Reserved
 
-import constraint
 import random
 from collections import defaultdict
 from typing import Any, Callable, Dict, Iterable, List, Optional, Set
@@ -526,19 +525,11 @@ class RandObj:
             while not constraints_satisfied:
                 if attempts == max:
                     break
-                problem = constraint.Problem()
-                for var_name in constrained_var_names:
-                    problem.addVariable(var_name, (result[var_name],))
-                for _constraint, variables in constraints:
-                    problem.addConstraint(_constraint, variables)
-                solutions = problem.getSolutions()
-                if len(solutions) > 0:
-                    # At least one solution was found, all is well
+                if utils.check_constraints(constraints, result):
+                    # The current values satisfy the constraints, all is well
                     constraints_satisfied = True
-                    solution = self._get_random().choice(solutions)
-                    result.update(solution)
                 else:
-                    # No solution found, re-randomize and try again
+                    # Constraints not satisfied, re-randomize and try again
                     # List length variables first
                     for list_length_name in list_length_names:
                         # If the length-defining variable is constrained,

--- a/constrainedrandom/utils.py
+++ b/constrainedrandom/utils.py
@@ -61,6 +61,30 @@ def unique(list_variable: Iterable[Any]) -> bool:
     return True
 
 
+def check_constraints(
+    constraints: Iterable[ConstraintAndVars],
+    values: Dict[str, Any],
+) -> bool:
+    '''
+    Check concrete values against constraints.
+
+    Much faster than constructing a ``constraint.Problem``
+    when the values are already concrete, as there is no
+    solution space to search. Stops at the first
+    unsatisfied constraint.
+
+    :param constraints: Constraints and the names of the
+        variables they apply to.
+    :param values: Concrete values, keyed by variable name.
+    :return: ``True`` if all constraints are satisfied,
+        ``False`` otherwise.
+    '''
+    return all(
+        constr(*(values[var_name] for var_name in var_names))
+        for constr, var_names in constraints
+    )
+
+
 def is_pure(function: Callable) -> bool:
     '''
     Determine whether a function is "pure", i.e. its return value

--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -59,6 +59,10 @@ Repeatability
 
 The ``RandObj`` class uses the standard Python ``random`` package under the hood. ``random`` provides repeatable randomization when given the same seed.
 
+Repeatability is guaranteed for a given seed and a given version of ``constrainedrandom``. Future development may change the values produced for a given seed. A release that only increments the patch version must not change randomization results. A release that does change the values produced for a given seed increments at least the minor version, with an explanation in the release notes.
+
+For example, the same seed produces identical results on ``1.2.2`` and ``1.2.3``, but may produce different results on ``1.3.0``.
+
 There are two ways to seed the ``random`` package, either globally or using an instance of the ``random.Random`` class.
 
 Global seeding

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,14 @@ dependencies = [
     "python-constraint>=1.4.0",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "bokeh>=3.4.1",
+]
+benchmarks = [
+    "pyvsc",
+]
+
 [project.urls]
 "Homepage" = "https://github.com/will-keen/constrainedrandom"
 "Bug Tracker" = "https://github.com/will-keen/constrainedrandom/issues"

--- a/tests/README.md
+++ b/tests/README.md
@@ -32,7 +32,11 @@ python3 -m tests --perf
 
 Tests can optionally be tagged using `--perf-results-tag <tag>`. This can be useful to identify tests run with particular changes.
 
-Creating performance graphs requires the [`bokeh`](https://bokeh.org/) package to be installed at a version >= v3.4.1. This is not included in `constrainedrandom`'s `pyproject.toml` dependencies to avoid a bloated installation.
+Creating performance graphs requires the [`bokeh`](https://bokeh.org/) package to be installed at a version >= v3.4.1. This is not included in `constrainedrandom`'s core dependencies to avoid a bloated installation. Install it with the `dev` optional dependency group:
+
+```bash
+pip install -e ".[dev]"
+```
 
 To plot performance graphs, run the following:
 

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -11,6 +11,7 @@ from .main import main
 
 # Import all tests for unittest to run
 from .bits import *
+from .check_constraints import *
 from .determinism import *
 from .is_pure import *
 from .satisfies_constraints import *

--- a/tests/check_constraints.py
+++ b/tests/check_constraints.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Will Keen
+
+'''
+Test check_constraints function from utils.
+'''
+
+import unittest
+
+from constrainedrandom.utils import check_constraints
+
+
+def x_lt_y(x, y):
+    return x < y
+
+def x_nonzero(x):
+    return x != 0
+
+
+class CheckConstraintsTests(unittest.TestCase):
+    '''
+    Test the ``check_constraints`` function from ``utils``.
+    '''
+
+    CONSTRAINTS = [
+        (x_lt_y, ('x', 'y')),
+        (x_nonzero, ('x',)),
+    ]
+
+    def test_satisfied(self):
+        self.assertTrue(check_constraints(self.CONSTRAINTS, {'x': 1, 'y': 2}))
+
+    def test_unsatisfied(self):
+        # First constraint fails.
+        self.assertFalse(check_constraints(self.CONSTRAINTS, {'x': 2, 'y': 1}))
+        # Second constraint fails.
+        self.assertFalse(check_constraints(self.CONSTRAINTS, {'x': 0, 'y': 1}))
+
+    def test_no_constraints(self):
+        self.assertTrue(check_constraints([], {'x': 1}))
+
+    def test_early_exit(self):
+        # Constraints after the first failing one must not be called.
+        def fails(x):
+            return False
+        def must_not_run(x):
+            self.fail("constraint evaluated after an earlier one failed")
+        constraints = [(fails, ('x',)), (must_not_run, ('x',))]
+        self.assertFalse(check_constraints(constraints, {'x': 1}))


### PR DESCRIPTION
Stop constructing a `constraint.Problem` each time, instead check all the constraints against the chosen values.

Quicker because it doesn't need to construct a solution space, because we don't use it.